### PR TITLE
App 3117 copy release order

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -149,7 +149,6 @@ module ActiveRecord
         end
 
         def update_positions
-          debugger
           unless ActiveRecord::Acts::List.skip_cb
             tn = ActiveRecord::Base.connection.quote_table_name acts_as_list_class.table_name
             pk = ActiveRecord::Base.connection.quote_column_name acts_as_list_class.primary_key

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -23,6 +23,21 @@ module ActiveRecord
       #   todo_list.first.move_to_bottom
       #   todo_list.last.move_higher
       module ClassMethods
+        # Add ability to skip callbacks for save/update.
+        def self.skip_callbacks
+          begin
+            @skip_cb = true
+            yield
+          ensure
+            @skip_cb = false
+          end
+        end
+        
+        # Return .skip_cb value.
+        def self.skip_cb
+          @skip_cb
+        end
+        
         # Configuration options are:
         #
         # * +column+ - specifies the column name to use for keeping the position integer (default: +position+)
@@ -134,34 +149,36 @@ module ActiveRecord
         end
 
         def update_positions
-          tn = ActiveRecord::Base.connection.quote_table_name acts_as_list_class.table_name
-          pk = ActiveRecord::Base.connection.quote_column_name acts_as_list_class.primary_key
-          up = ActiveRecord::Base.connection.quote_table_name "updated_positions"
+          unless ActsAsList.skip_cb
+            tn = ActiveRecord::Base.connection.quote_table_name acts_as_list_class.table_name
+            pk = ActiveRecord::Base.connection.quote_column_name acts_as_list_class.primary_key
+            up = ActiveRecord::Base.connection.quote_table_name "updated_positions"
 
-          c = changes[position_column]
+            c = changes[position_column]
 
-          if c && c[0] && c[1] && (c[0] < c[1])
-            # the position moved UP
-            # We should order colliding positions by newest last
-            sort_order = "ASC"
-          else
-            # The position moved DOWN
-            # we should order colliding positions by newest first
-            sort_order = "DESC"
+            if c && c[0] && c[1] && (c[0] < c[1])
+              # the position moved UP
+              # We should order colliding positions by newest last
+              sort_order = "ASC"
+            else
+              # The position moved DOWN
+              # we should order colliding positions by newest first
+              sort_order = "DESC"
+            end
+
+            if add_new_at == :top
+              nulls_go = "FIRST"
+            else
+              nulls_go = "LAST"
+            end
+
+            window_function = acts_as_list_list
+              .select("row_number() OVER ( ORDER BY #{position_column} ASC NULLS #{nulls_go}, updated_at #{sort_order}) AS #{position_column}, #{pk}")
+              .to_sql
+
+            acts_as_list_class.connection.execute %{UPDATE #{tn} SET #{position_column} = #{up}.#{position_column}
+              FROM (#{window_function}) AS updated_positions WHERE #{tn}.#{pk}=#{up}.#{pk}}
           end
-
-          if add_new_at == :top
-            nulls_go = "FIRST"
-          else
-            nulls_go = "LAST"
-          end
-
-          window_function = acts_as_list_list
-            .select("row_number() OVER ( ORDER BY #{position_column} ASC NULLS #{nulls_go}, updated_at #{sort_order}) AS #{position_column}, #{pk}")
-            .to_sql
-
-          acts_as_list_class.connection.execute %{UPDATE #{tn} SET #{position_column} = #{up}.#{position_column}
-            FROM (#{window_function}) AS updated_positions WHERE #{tn}.#{pk}=#{up}.#{pk}}
         end
 
         def reload_position

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -7,17 +7,18 @@ module ActiveRecord
       
       # Add ability to skip callbacks for save/update.
       def self.skip_callbacks
+        old_skip_cb = @skip_cb
+        @skip_cb = true
         begin
-          @skip_cb = true
           yield
         ensure
-          @skip_cb = false
+          @skip_cb = old_skip_cb
         end
       end
         
       # Return .skip_cb value.
-      def self.skip_cb
-        @skip_cb
+      def self.skip_cb?
+        @skip_cb == true
       end
 
       # This +acts_as+ extension provides the capabilities for sorting and reordering a number of objects in a list.
@@ -129,7 +130,7 @@ module ActiveRecord
             end
 
             after_destroy :update_positions
-            after_create :update_positions, unless: Proc.new{ ActiveRecord::Acts::List.skip_cb }
+            after_create :update_positions, unless: Proc.new{ ActiveRecord::Acts::List.skip_cb? }
             after_update :update_positions_if_necessary
 
             scope :in_list, lambda { where("#{table_name}.#{configuration[:column]} IS NOT NULL") }

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -4,6 +4,21 @@ module ActiveRecord
       def self.included(base)
         base.extend(ClassMethods)
       end
+      
+      # Add ability to skip callbacks for save/update.
+      def self.skip_callbacks
+        begin
+          @skip_cb = true
+          yield
+        ensure
+          @skip_cb = false
+        end
+      end
+      
+      # Return .skip_cb value.
+      def self.skip_cb
+        @skip_cb
+      end
 
       # This +acts_as+ extension provides the capabilities for sorting and reordering a number of objects in a list.
       # The class that has this specified needs to have a +position+ column defined as an integer on
@@ -23,21 +38,6 @@ module ActiveRecord
       #   todo_list.first.move_to_bottom
       #   todo_list.last.move_higher
       module ClassMethods
-        # Add ability to skip callbacks for save/update.
-        def self.skip_callbacks
-          begin
-            @skip_cb = true
-            yield
-          ensure
-            @skip_cb = false
-          end
-        end
-        
-        # Return .skip_cb value.
-        def self.skip_cb
-          @skip_cb
-        end
-        
         # Configuration options are:
         #
         # * +column+ - specifies the column name to use for keeping the position integer (default: +position+)
@@ -149,7 +149,8 @@ module ActiveRecord
         end
 
         def update_positions
-          unless ActsAsList.skip_cb
+          debugger
+          unless ActiveRecord::Acts::List.skip_cb
             tn = ActiveRecord::Base.connection.quote_table_name acts_as_list_class.table_name
             pk = ActiveRecord::Base.connection.quote_column_name acts_as_list_class.primary_key
             up = ActiveRecord::Base.connection.quote_table_name "updated_positions"

--- a/lib/acts_as_list/version.rb
+++ b/lib/acts_as_list/version.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Acts
     module List
-      VERSION = '0.8.8'
+      VERSION = '0.8.9'
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/aha-app/aha-app/pull/1322

acts_as_list automatically manages positions of objects which are created, automatically sorting them in order based on the order of their creation. While this usually works as expected, when **cloning a release** we are taking things (like features) which already have an order and we are creating copies of them in a new release.

Because the saving of these clones of features does not necessarily happen in any order, it is possible that cloning a release can cause the features within that cloned release to suddenly and spontaneously have a new position assigned to them which differs than the position the original (non-cloned) feature had.

This PR gives us a way to turn off the automatic reordering of lists, to be used in circumstances like cloning a release.