### PR TITLE
Allow all hook callbacks to be skipped if needed

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -129,9 +129,9 @@ module ActiveRecord
               attr_accessible :#{configuration[:column]}
             end
 
-            after_destroy :update_positions
-            after_create :update_positions, unless: Proc.new{ ActiveRecord::Acts::List.skip_cb? }
-            after_update :update_positions_if_necessary
+            after_destroy :update_positions, unless: -> { ActiveRecord::Acts::List.skip_cb? }
+            after_create :update_positions, unless: -> { ActiveRecord::Acts::List.skip_cb? }
+            after_update :update_positions_if_necessary, unless: -> { ActiveRecord::Acts::List.skip_cb? }
 
             scope :in_list, lambda { where("#{table_name}.#{configuration[:column]} IS NOT NULL") }
           EOV

--- a/lib/acts_as_list/version.rb
+++ b/lib/acts_as_list/version.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Acts
     module List
-      VERSION = '0.8.9'
+      VERSION = '0.8.10'
     end
   end
 end


### PR DESCRIPTION
Allow all added AR hooks to be skipped using the `skip_callbacks` method.