### PR TITLE
Introduce method to reposition multiple items at once

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -135,7 +135,7 @@ module ActiveRecord
 
             scope :in_list, lambda { where("#{table_name}.#{configuration[:column]} IS NOT NULL") }
 
-            def self.insert_after_record_with_position(records, targeted_record_position)
+            def self.move_after_record_with_position(records, targeted_record_position)
               transaction do
                 ActiveRecord::Acts::List.skip_callbacks do
                   records.reverse.each do |record|

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -134,6 +134,19 @@ module ActiveRecord
             after_update :update_positions_if_necessary, unless: -> { ActiveRecord::Acts::List.skip_cb? }
 
             scope :in_list, lambda { where("#{table_name}.#{configuration[:column]} IS NOT NULL") }
+
+            def self.insert_after_record_with_position(records, targeted_record_position)
+              transaction do
+                ActiveRecord::Acts::List.skip_callbacks do
+                  records.reverse.each do |record|
+                    record.update(#{configuration[:column]}: targeted_record_position.to_i + 1)
+                    record.touch
+                  end
+                end
+
+                records.first&.update_positions
+              end
+            end
           EOV
 
           self.send(:before_create, "add_to_list_#{configuration[:add_new_at]}")


### PR DESCRIPTION
This introduces a method to allow repositioning multiple records at once by placing them after the record with the passed in position.