### PR TITLE
Lock using primary key order to avoid deadlocks on update

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -228,6 +228,7 @@ module ActiveRecord
           if ActiveRecord::Acts::List.delayed_updates?
             delay(unique: true, in: 10.seconds)._execute_position_update!(sql)
           else
+            acts_as_list_list.lock.reorder(acts_as_list_class.primary_key).pluck(acts_as_list_class.primary_key)
             _execute_position_update!(sql)
           end
         end


### PR DESCRIPTION
The window function that actually applies the new positions would update records
in a different sequence for each transaction, causing deadlocks.

This ensures that before we update the records out of order, we first claim a
lock on them, consistently ordered by primary key.